### PR TITLE
Change api group to av.mittwald.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ This operator consists of several components:
 
 ### Starting an AV scan on demand
 
-An on-demand scan is modelled using the `VirusScan` custom resource (API group `av.mittwald.systems/v1beta1`). In the `.spec` of a virus scan you can specify which files to scan and which engine to use (currently, only ClamAV is supported):
+An on-demand scan is modelled using the `VirusScan` custom resource (API group `av.mittwald.de/v1beta1`). In the `.spec` of a virus scan you can specify which files to scan and which engine to use (currently, only ClamAV is supported):
 
 ```yaml
-apiVersion: av.mittwald.systems/v1beta1
+apiVersion: av.mittwald.de/v1beta1
 kind: VirusScan
 metadata:
   name: example-virusscan
@@ -107,7 +107,7 @@ example-virusscan   Completed (1 infected files)   44s         11s         44s
 The `.status.scanResults` property in the CR lists the individual files found by the scanner:
 
 ```yaml
-apiVersion: av.mittwald.systems/v1beta1
+apiVersion: av.mittwald.de/v1beta1
 kind: VirusScan
 metadata:
   name: example-virusscan
@@ -134,7 +134,7 @@ status:
 Periodic scanning can be configured using the `ScheduledVirusScan` resource.
 
 ```yaml
-apiVersion: av.mittwald.systems/v1beta1
+apiVersion: av.mittwald.de/v1beta1
 kind: ScheduledVirusScan
 metadata:
   name: example-scheduledvirusscan

--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -15,7 +15,7 @@ rules:
   - get
   - watch
 - apiGroups:
-  - av.mittwald.systems
+  - av.mittwald.de
   resources:
   - virusscans
   verbs:
@@ -23,7 +23,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - av.mittwald.systems
+  - av.mittwald.de
   resources:
   - virusscans/status
   verbs:

--- a/deploy/crds/av.mittwald.de_scheduledvirusscans_crd.yaml
+++ b/deploy/crds/av.mittwald.de_scheduledvirusscans_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: scheduledvirusscans.av.mittwald.systems
+  name: scheduledvirusscans.av.mittwald.de
 spec:
-  group: av.mittwald.systems
+  group: av.mittwald.de
   names:
     kind: ScheduledVirusScan
     listKind: ScheduledVirusScanList

--- a/deploy/crds/av.mittwald.de_v1beta1_scheduledvirusscan_cr.yaml
+++ b/deploy/crds/av.mittwald.de_v1beta1_scheduledvirusscan_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: av.mittwald.systems/v1beta1
+apiVersion: av.mittwald.de/v1beta1
 kind: ScheduledVirusScan
 metadata:
   name: example-scheduledvirusscan

--- a/deploy/crds/av.mittwald.de_v1beta1_virusscan_cr.yaml
+++ b/deploy/crds/av.mittwald.de_v1beta1_virusscan_cr.yaml
@@ -1,4 +1,4 @@
-apiVersion: av.mittwald.systems/v1beta1
+apiVersion: av.mittwald.de/v1beta1
 kind: VirusScan
 metadata:
   name: example-virusscan

--- a/deploy/crds/av.mittwald.de_virusscans_crd.yaml
+++ b/deploy/crds/av.mittwald.de_virusscans_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: virusscans.av.mittwald.systems
+  name: virusscans.av.mittwald.de
 spec:
-  group: av.mittwald.systems
+  group: av.mittwald.de
   names:
     kind: VirusScan
     listKind: VirusScanList

--- a/deploy/helm-chart/kubeav/Chart.yaml
+++ b/deploy/helm-chart/kubeav/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kubeav
 description: AntiVirus automation for Kubernetes
 type: application
-version: 1.0.0-alpha5
-appVersion: v1.0.0-alpha5
+version: 1.0.0-alpha6
+appVersion: v1.0.0-alpha6

--- a/deploy/helm-chart/kubeav/crds/av.mittwald.de_scheduledvirusscans_crd.yaml
+++ b/deploy/helm-chart/kubeav/crds/av.mittwald.de_scheduledvirusscans_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: scheduledvirusscans.av.mittwald.systems
+  name: scheduledvirusscans.av.mittwald.de
 spec:
-  group: av.mittwald.systems
+  group: av.mittwald.de
   names:
     kind: ScheduledVirusScan
     listKind: ScheduledVirusScanList

--- a/deploy/helm-chart/kubeav/crds/av.mittwald.de_virusscans_crd.yaml
+++ b/deploy/helm-chart/kubeav/crds/av.mittwald.de_virusscans_crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: virusscans.av.mittwald.systems
+  name: virusscans.av.mittwald.de
 spec:
-  group: av.mittwald.systems
+  group: av.mittwald.de
   names:
     kind: VirusScan
     listKind: VirusScanList

--- a/deploy/helm-chart/kubeav/templates/clusterrole_agent.yaml
+++ b/deploy/helm-chart/kubeav/templates/clusterrole_agent.yaml
@@ -16,7 +16,7 @@ rules:
   - get
   - watch
 - apiGroups:
-  - av.mittwald.systems
+  - av.mittwald.de
   resources:
   - virusscans
   verbs:
@@ -24,7 +24,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - av.mittwald.systems
+  - av.mittwald.de
   resources:
   - virusscans/status
   verbs:

--- a/deploy/helm-chart/kubeav/templates/clusterrole_operator.yaml
+++ b/deploy/helm-chart/kubeav/templates/clusterrole_operator.yaml
@@ -27,7 +27,7 @@ rules:
 - apiGroups: ["apps"]
   resources: [daemonsets]
   verbs: [list, watch, get]
-- apiGroups: ['av.mittwald.systems']
+- apiGroups: ['av.mittwald.de']
   resources:
     - virusscans
     - scheduledvirusscans
@@ -35,13 +35,13 @@ rules:
     - get
     - list
     - watch
-- apiGroups: ['av.mittwald.systems']
+- apiGroups: ['av.mittwald.de']
   resources:
     - virusscans
   verbs:
     - create
     - delete
-- apiGroups: ['av.mittwald.systems']
+- apiGroups: ['av.mittwald.de']
   resources:
     - virusscans/status
     - scheduledvirusscans/status

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -67,7 +67,7 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - av.mittwald.systems
+  - av.mittwald.de
   resources:
   - '*'
   - scheduledvirusscans

--- a/pkg/apis/av/v1beta1/doc.go
+++ b/pkg/apis/av/v1beta1/doc.go
@@ -1,4 +1,4 @@
 // Package v1beta1 contains API Schema definitions for the av v1beta1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=av.mittwald.systems
+// +groupName=av.mittwald.de
 package v1beta1

--- a/pkg/apis/av/v1beta1/register.go
+++ b/pkg/apis/av/v1beta1/register.go
@@ -1,8 +1,6 @@
-// NOTE: Boilerplate only.  Ignore this file.
-
 // Package v1beta1 contains API Schema definitions for the av v1beta1 API group
 // +k8s:deepcopy-gen=package,register
-// +groupName=av.mittwald.systems
+// +groupName=av.mittwald.de
 package v1beta1
 
 import (
@@ -12,7 +10,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "av.mittwald.systems", Version: "v1beta1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "av.mittwald.de", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/pkg/controller/scheduledvirusscan/controller.go
+++ b/pkg/controller/scheduledvirusscan/controller.go
@@ -27,7 +27,7 @@ import (
 
 var log = logf.Log.WithName("controller_scheduledvirusscan")
 
-const labelScheduledBy = "kubeav.mittwald.systems/scheduled-by"
+const labelScheduledBy = "kubeav.mittwald.de/scheduled-by"
 
 // Add creates a new ScheduledVirusScan Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.


### PR DESCRIPTION
Change api group to `av.mittwald.de`, since the usual domain for api groups of other Mittwald operators is `mittwald.de`, too.